### PR TITLE
Fix lint issues with typed APIs and hooks (follow-up)

### DIFF
--- a/src/hooks/useCache.ts
+++ b/src/hooks/useCache.ts
@@ -41,7 +41,7 @@ class Cache {
       return null
     }
 
-    return entry.data
+    return entry.data as T
   }
 
   delete(key: string): void {


### PR DESCRIPTION
## Summary
- cast cached entries when returning from the cache helper so the generic get<T> contract is satisfied

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68fb321b88008323828609a047bb520c